### PR TITLE
Hide helpfulness box on landing

### DIFF
--- a/src/kubernetes-tool/scss/style.scss
+++ b/src/kubernetes-tool/scss/style.scss
@@ -36,6 +36,12 @@ $header: #0071fe;
 @import "~do-bulma/src/style";
 
 .do-bulma {
+  &.landing {
+    + .helpfulness-cont {
+      display: none;
+    }
+  }
+
   .landing {
     .container {
       .container {

--- a/src/kubernetes-tool/templates/app.vue
+++ b/src/kubernetes-tool/templates/app.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <template>
-    <div class="all do-bulma">
+    <div :class="`all do-bulma${Object.keys(toBeRendered).length === 0 ? ' landing' : ''}`">
         <div v-if="Object.keys(toBeRendered).length === 0">
             <SplashScreen @result="resultSet" />
         </div>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue, SASS

## What issue does this relate to?

Internal PR 1415

### What should this PR do?

Adds a landing class to the top-level app container that then hides the helpfulness box that we will soon be rendering on all tool pages.

### What are the acceptance criteria?

I've tested this locally with 1415 pulled down, it works.